### PR TITLE
Hotfix relative imports

### DIFF
--- a/examples/AdvancedExamples/ChromaticModelFit.py
+++ b/examples/AdvancedExamples/ChromaticModelFit.py
@@ -4,10 +4,11 @@ Created on Tue Nov 15 11:53:04 2022
 
 @author: Ame
 """
-from pprint import pprint as print 
-import oimodeler as oim
-import numpy as np                                         
 import os
+from pprint import pprint as print 
+
+import numpy as np                                         
+import oimodeler as oim
 
 path = os.path.dirname(oim.__file__)
 pathData=os.path.join(os.path.join(path,os.pardir,"examples","testData","ASPRO_CHROMATIC_SKWDISK"))

--- a/examples/AdvancedExamples/complexModels.py
+++ b/examples/AdvancedExamples/complexModels.py
@@ -1,7 +1,8 @@
-import oimodeler as oim
-import numpy as np
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import oimodeler as oim
 
 path = os.path.dirname(oim.__file__)
 

--- a/examples/AdvancedExamples/paramInterpolators.py
+++ b/examples/AdvancedExamples/paramInterpolators.py
@@ -4,13 +4,13 @@ Created on Fri Oct 28 12:21:51 2022
 
 @author: Ame
 """
+import os
 
-import oimodeler as oim
-import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import matplotlib.cm as cm
-import os
+import numpy as np
+import oimodeler as oim
 
 path = os.path.dirname(oim.__file__)
 

--- a/examples/AdvancedExamples/timeDependentModelFit.py
+++ b/examples/AdvancedExamples/timeDependentModelFit.py
@@ -1,7 +1,8 @@
-import oimodeler as oim
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
 import numpy as np
+import oimodeler as oim
 
 path = os.path.dirname(oim.__file__)
 pathData=os.path.join(path,os.pardir,"examples","testData","ASPRO_SPICA_GROWING_UD")

--- a/examples/BasicExamples/FitsImageCubeModels.py
+++ b/examples/BasicExamples/FitsImageCubeModels.py
@@ -4,14 +4,14 @@ Created on Thu Jan 26 12:03:58 2023
 
 @author: Ame
 """
+import os
+from pprint import pprint as print
 
-import oimodeler as oim
-from matplotlib import pyplot as plt
 import matplotlib.colors as colors
 import matplotlib.cm as cm
 import numpy as np
-import os
-from pprint import pprint as print
+import oimodeler as oim
+from matplotlib import pyplot as plt
 
 
 #You can change FFT option, for instance reduce the standard zero-padding factor 

--- a/examples/BasicExamples/basicModels.py
+++ b/examples/BasicExamples/basicModels.py
@@ -1,7 +1,8 @@
-import oimodeler as oim
-import numpy as np
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import oimodeler as oim
 
 path = os.path.dirname(oim.__file__)
 

--- a/examples/BasicExamples/exampleOimData.py
+++ b/examples/BasicExamples/exampleOimData.py
@@ -4,9 +4,9 @@ Created on Wed Jun 29 16:16:59 2022
 
 @author: Ame
 """
+import os
 
 import oimodeler as oim
-import os
 
 path = os.path.dirname(oim.__file__)
 pathData=os.path.join(path,os.pardir,"examples","testData","FSCMa_MATISSE")

--- a/examples/BasicExamples/exampleOimDataFilter.py
+++ b/examples/BasicExamples/exampleOimDataFilter.py
@@ -4,12 +4,11 @@ Created on Mon Sep 26 09:08:46 2022
 
 @author: Ame
 """
-
-
-import oimodeler as oim
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
 import numpy as np
+import oimodeler as oim
 from astropy.io import fits
 
 path = os.path.dirname(oim.__file__)

--- a/examples/BasicExamples/exampleOimFitterEmcee.py
+++ b/examples/BasicExamples/exampleOimFitterEmcee.py
@@ -4,9 +4,9 @@ Created on Wed Sep 21 10:59:15 2022
 
 @author: Ame
 """
+import os
 
 import oimodeler as oim
-import os
 
 path = os.path.dirname(oim.__file__)
 

--- a/examples/BasicExamples/exampleOimPlot.py
+++ b/examples/BasicExamples/exampleOimPlot.py
@@ -4,8 +4,9 @@ Created on Sat Sep 10 07:28:17 2022
 
 @author: Ame
 """
-import matplotlib.pyplot as plt
 import os
+
+import matplotlib.pyplot as plt
 import oimodeler as oim
 
 path = os.path.dirname(oim.__file__)

--- a/examples/BasicExamples/exampleOimSimulator.py
+++ b/examples/BasicExamples/exampleOimSimulator.py
@@ -4,9 +4,9 @@ Created on Wed Jun 29 16:16:59 2022
 
 @author: Ame
 """
+import os
 
 import oimodeler as oim
-import os
 
 
 

--- a/examples/BasicExamples/fitsImageModel.py
+++ b/examples/BasicExamples/fitsImageModel.py
@@ -4,13 +4,13 @@ Created on Thu Jan 26 12:03:58 2023
 
 @author: Ame
 """
-
-import oimodeler as oim
-from matplotlib import pyplot as plt
-import numpy as np
 import os
-from astropy.io import fits
 from pprint import pprint as print
+
+import numpy as np
+import oimodeler as oim
+from astropy.io import fits
+from matplotlib import pyplot as plt
 
 #You can change FFT option, for instance reduce the standard zero-padding factor 
 #from 8 to 2 or use FFTW backend instead of the standard numpy FFT module

--- a/examples/BasicExamples/gettingStarted.py
+++ b/examples/BasicExamples/gettingStarted.py
@@ -4,11 +4,12 @@ Created on Wed Sep 21 10:59:15 2022
 
 @author: Ame
 """
-import oimodeler as oim
+import os
 from pprint import pprint as print
 
+import oimodeler as oim
+
 #%%
-import os
 path = os.path.dirname(oim.__file__)
 pathData=os.path.join(path,os.pardir,"examples","testData","ASPRO_MATISSE2")
 files=[os.path.abspath(os.path.join(pathData,fi)) for fi in os.listdir(pathData)]

--- a/examples/ExpandingSoftware/createCustomComponentFourier.py
+++ b/examples/ExpandingSoftware/createCustomComponentFourier.py
@@ -12,13 +12,13 @@ Complex visibility for North-South and East-West baselines between 0 and 100m
 are computed for both models and plotted as well as images.
 
 """
-
-import oimodeler as oim
-import matplotlib.pyplot as plt
-#import matplotlib.colors as colors
-import numpy as np
-import astropy.units as u
 import os
+
+import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
+import oimodeler as oim
+
 
 path = os.path.dirname(oim.__file__)
 

--- a/examples/ExpandingSoftware/createCustomComponentImageFastRotator.py
+++ b/examples/ExpandingSoftware/createCustomComponentImageFastRotator.py
@@ -4,14 +4,15 @@ Created on Wed Oct 19 12:30:21 2022
 
 @author: Ame
 """
-import numpy as np
-import matplotlib.pyplot as plt
+import os
+
 import matplotlib.colors as colors
 import matplotlib.cm as cm
-from astropy import units as units
+import matplotlib.pyplot as plt
+import numpy as np
 import oimodeler as oim
+from astropy import units as units
 
-import os
 
 path = os.path.dirname(oim.__file__)
 

--- a/examples/ExpandingSoftware/createCustomComponentImageSpiral.py
+++ b/examples/ExpandingSoftware/createCustomComponentImageSpiral.py
@@ -4,14 +4,14 @@ Created on Fri Oct 21 12:27:15 2022
 
 @author: Ame
 """
+import os
 
-import numpy as np
-import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+import numpy as np
 import oimodeler as oim
 from astropy import units as units
-import os
 
 path = os.path.dirname(oim.__file__)
 

--- a/examples/ExpandingSoftware/createCustomComponentRadialProfileExpRing.py
+++ b/examples/ExpandingSoftware/createCustomComponentRadialProfileExpRing.py
@@ -4,12 +4,11 @@ Created on Tue Dec 14 14:39:36 2021
 
 @author: Ame
 """
-
-import numpy as np
+import astropy.units as u
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
+import numpy as np
 import oimodeler as oim
-import astropy.units as u
 
 
 

--- a/examples/ExpandingSoftware/createCustomParamInterpolator.py
+++ b/examples/ExpandingSoftware/createCustomParamInterpolator.py
@@ -4,11 +4,10 @@ Created on Fri Oct 21 12:27:15 2022
 
 @author: Ame
 """
-
-import numpy as np
-import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+import numpy as np
 import oimodeler as oim
 from scipy.interpolate import interp1d
 

--- a/examples/ExpandingSoftware/usingCustomComponents.py
+++ b/examples/ExpandingSoftware/usingCustomComponents.py
@@ -4,17 +4,18 @@ Created on Wed Oct 19 12:30:21 2022
 
 @author: Ame
 """
-import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.colors as colors
-import matplotlib.cm as cm
-from astropy import units as units
-import oimodeler as oim
-from oimodeler.oimCustomComponents import oimFastRotator,oimSpiral,oimBox
 import os
+
+import matplotlib.cm as cm
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
+import numpy as np
+import oimodeler as oim
+from astropy import units as units
+from oimodeler.oimCustomComponents import oimFastRotator,oimSpiral,oimBox
+
+
 path = os.path.dirname(oim.__file__)
-
-
 
 #%% Creating a model
 

--- a/examples/Other/createModelChromatic.py
+++ b/examples/Other/createModelChromatic.py
@@ -1,14 +1,16 @@
-import oimodeler as oim
+import os
+
+import astropy.units as u
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import matplotlib.cm as cm
 import numpy as np
-import astropy.units as u
-import os
+import oimodeler as oim
+
+
 path = os.path.dirname(oim.__file__)
 
 mas2rad=u.mas.to(u.rad)
-
 
 #Some components
 gd=oim.oimGauss(fwhm=oim.oimInterpWl(wl=[3e-6,3.5e-6,4e-6],value=[1,3,4]),

--- a/examples/PerformanceTests/simulator_ComputationTime.py
+++ b/examples/PerformanceTests/simulator_ComputationTime.py
@@ -4,12 +4,12 @@ Created on Wed Jun 29 16:16:59 2022
 
 @author: Ame
 """
-
-import oimodeler as oim
-import matplotlib.pyplot as plt
-import numpy as np
 import os
 from datetime import datetime
+
+import matplotlib.pyplot as plt
+import numpy as np
+import oimodeler as oim
 from tqdm import tqdm
 
 path = os.path.dirname(oim.__file__)

--- a/examples/PerformanceTests/simulator_ComputationTimeRatio.py
+++ b/examples/PerformanceTests/simulator_ComputationTimeRatio.py
@@ -4,11 +4,11 @@ Created on Wed Jun 29 16:16:59 2022
 
 @author: Ame
 """
+import os
 
-import oimodeler as oim
 import matplotlib.pyplot as plt
 import numpy as np
-import os
+import oimodeler as oim
 from datetime import datetime
 from tqdm import tqdm
 

--- a/examples/testSuite/realDataFit.py
+++ b/examples/testSuite/realDataFit.py
@@ -4,15 +4,17 @@ Created on Tue Nov 15 11:53:04 2022
 
 @author: Ame
 """
-from pprint import pprint as print 
-import oimodeler as oim
-import numpy as np                                         
 import os
 from datetime import datetime
-import matplotlib.pyplot as plt
-import matplotlib
-matplotlib.use('Agg')
+from pprint import pprint as print 
 
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np                                         
+import oimodeler as oim
+
+
+matplotlib.use('Agg')
 
 name="realData"
 

--- a/examples/testSuite/simpleModelsASPROdataFit.py
+++ b/examples/testSuite/simpleModelsASPROdataFit.py
@@ -4,16 +4,17 @@ Created on Tue Nov 15 11:53:04 2022
 
 @author: Ame
 """
-from pprint import pprint as print 
-import oimodeler as oim
-import numpy as np                                         
 import os
 from datetime import datetime
-import matplotlib.pyplot as plt
+from pprint import pprint as print 
 
 import matplotlib
-matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np                                         
+import oimodeler as oim
 
+
+matplotlib.use('Agg')
 
 name="simpleASPRO"
 path = os.path.dirname(oim.__file__)

--- a/oimodeler/__init__.py
+++ b/oimodeler/__init__.py
@@ -4,30 +4,30 @@ Created on Tue Nov 23 15:26:42 2021
 
 @author: Ame
 """
+import inspect
+from os.path import join, dirname, split
 
-from .oimOptions import oimOptions
-from .oimFTBackends import *
-from .oimParam import *
-from .oimParam import _standardParameters
-from .oimModel import *
-from .oimComponent import *
+import matplotlib.projections as proj
+import numpy as np
+
 from .oimBasicFourierComponents import *
+from .oimComponent import *
 from .oimCustomComponents import *
 from .oimData import *
 from .oimData import _oimDataType, _oimDataTypeErr, _oimDataTypeArr
+from .oimDataFilter import *
 from .oimFitter import *
+from .oimFTBackends import *
+from .oimModel import *
+from .oimOptions import oimOptions
+from .oimParam import *
+from .oimParam import _standardParameters
+from .oimPlots import *
 from .oimSimulator import *
 from .oimUtils import *
-from .oimDataFilter import *
-from .oimPlots import *
 
 
-import numpy as np
 np.seterr(invalid='ignore')
-
-from os.path import join, dirname, split
-import inspect
-import matplotlib.projections as proj
 
 proj.register_projection(oimAxes)
 
@@ -38,4 +38,3 @@ if split(__pkg_dir__)[-1] == "":
     __git_dir__ = dirname(split(__pkg_dir__)[0])
 else:
     __git_dir__ = split(__pkg_dir__)[0]
-

--- a/oimodeler/__init__.py
+++ b/oimodeler/__init__.py
@@ -11,20 +11,12 @@ import matplotlib.projections as proj
 import numpy as np
 
 from .oimBasicFourierComponents import *
-from .oimComponent import *
 from .oimCustomComponents import *
-from .oimData import *
-from .oimData import _oimDataType, _oimDataTypeErr, _oimDataTypeArr
-from .oimDataFilter import *
-from .oimFitter import *
-from .oimFTBackends import *
-from .oimModel import *
-from .oimOptions import oimOptions
-from .oimParam import *
-from .oimParam import _standardParameters
-from .oimPlots import *
-from .oimSimulator import *
-from .oimUtils import *
+from .oimData import oimData
+from .oimFitter import oimFitterEmcee
+from .oimModel import oimModel
+from .oimPlots import oimAxes, oimPlot
+from .oimSimulator import oimSimulator
 
 
 np.seterr(invalid='ignore')

--- a/oimodeler/oimBasicFourierComponents.py
+++ b/oimodeler/oimBasicFourierComponents.py
@@ -6,7 +6,8 @@ import numpy as np
 from astropy import units as units
 from scipy.special import j0,j1,jv
 
-from oimodeler import oimParam,_standardParameters,oimComponentFourier
+from .oimComponent import oimComponentFourier
+from .oimParam import oimParam, _standardParameters
 
       
 ###############################################################################

--- a/oimodeler/oimBasicFourierComponents.py
+++ b/oimodeler/oimBasicFourierComponents.py
@@ -2,7 +2,6 @@
 """
 basic model-components defined in the Fourier plan
 """
-
 import numpy as np
 from astropy import units as units
 from scipy.special import j0,j1,jv

--- a/oimodeler/oimComponent.py
+++ b/oimodeler/oimComponent.py
@@ -5,12 +5,13 @@ based components defined in Fourier or image plan
 """
 
 import numpy as np
+from astropy.io import fits
 from astropy import units as units
 from scipy import interpolate,integrate
 from scipy.special import j0
+
 import oimodeler as oim
 from oimodeler import oimParam,_standardParameters,oimParamInterpolator,oimInterp
-from astropy.io import fits
 
 ###############################################################################
 #TODO move somewhere else

--- a/oimodeler/oimComponent.py
+++ b/oimodeler/oimComponent.py
@@ -10,6 +10,7 @@ from astropy import units as units
 from scipy import interpolate,integrate
 from scipy.special import j0
 
+from . import __dict__ as oimDict
 from .oimUtils import getWlFromFitsImageCube
 from .oimOptions import oimOptions
 from .oimParam import oimInterp, oimParam, oimParamInterpolator, _standardParameters
@@ -30,11 +31,11 @@ def getFourierComponents():
         
     :meta private:
     """
-    fnames=dir(oim)
+    fnames=dir()
     res=[]
     for f in fnames:
         try:
-            if issubclass(oim.__dict__[f], oimComponentFourier):
+            if issubclass(oimDict[f], oimComponentFourier):
                 res.append(f)
         except:
             pass

--- a/oimodeler/oimComponent.py
+++ b/oimodeler/oimComponent.py
@@ -10,8 +10,10 @@ from astropy import units as units
 from scipy import interpolate,integrate
 from scipy.special import j0
 
-import oimodeler as oim
-from oimodeler import oimParam,_standardParameters,oimParamInterpolator,oimInterp
+from .oimUtils import getWlFromFitsImageCube
+from .oimOptions import oimOptions
+from .oimParam import oimInterp, oimParam, oimParamInterpolator, _standardParameters
+
 
 ###############################################################################
 #TODO move somewhere else
@@ -32,7 +34,7 @@ def getFourierComponents():
     res=[]
     for f in fnames:
         try:
-            if issubclass(oim.__dict__[f], oim.oimComponentFourier):
+            if issubclass(oim.__dict__[f], oimComponentFourier):
                 res.append(f)
         except:
             pass
@@ -306,7 +308,7 @@ class oimComponentImage(oimComponent):
         if 'FTBackend' in kwargs:
              self.FTBackend=kwargs['FTBackend']
         else: 
-            self.FTBackend=oim.oimOptions['FTBackend']
+            self.FTBackend=oimOptions['FTBackend']
             
         self.FTBackendData=None
         
@@ -461,8 +463,8 @@ class oimComponentImage(oimComponent):
         s0x=np.trim_zeros(im0x).size
         s0y=np.trim_zeros(im0y).size
         
-        min_sizex=s0x*oim.oimOptions["FTpaddingFactor"]
-        min_sizey=s0y*oim.oimOptions["FTpaddingFactor"]
+        min_sizex=s0x*oimOptions["FTpaddingFactor"]
+        min_sizey=s0y*oimOptions["FTpaddingFactor"]
         
         min_pow2x=2**(min_sizex - 1).bit_length()
         min_pow2y=2**(min_sizey - 1).bit_length()
@@ -549,7 +551,7 @@ class oimComponentRadialProfile(oimComponent):
     @staticmethod
     def fht(Ir,r,wlin,tin,sfreq,wl,t):
         
-        pad=oim.oimOptions['FTpaddingFactor']
+        pad=oimOptions['FTpaddingFactor']
         nr=r.size
         ntin=tin.size
         nwlin=wlin.size
@@ -764,7 +766,7 @@ class oimComponentFitsImage(oimComponentImage):
         if 'FTBackend' in kwargs:
              self.FTBackend=kwargs['FTBackend']
         else: 
-            self.FTBackend=oim.oimOptions['FTBackend']
+            self.FTBackend=oimOptions['FTBackend']
             
         self.FTBackendData=None
         
@@ -805,7 +807,7 @@ class oimComponentFitsImage(oimComponentImage):
         
           
         if dims==3:
-            self._wl=oim.getWlFromFitsImageCube(self._header)
+            self._wl=getWlFromFitsImageCube(self._header)
             self._image=im.data[None,:,:,:]  #adding the time dimension (nt,nwl,ny,nx)
         
         else:

--- a/oimodeler/oimCustomComponents/__init__.py
+++ b/oimodeler/oimCustomComponents/__init__.py
@@ -16,7 +16,6 @@ directory add the import here so that all component will be available through
 
 #TODO: import crashes randomly with ModuleNotFoundError: No module named 'oimFastRotator' 
 
-
+from .oimBox import oimBox
 from .oimFastRotator import oimFastRotator
 from .oimSpiral import oimSpiral
-from .oimBox import oimBox

--- a/oimodeler/oimCustomComponents/oimBox.py
+++ b/oimodeler/oimCustomComponents/oimBox.py
@@ -1,9 +1,9 @@
 import astropy.units as u
 import numpy as np
 
-from oimodeler import oimComponentFourier,oimParam
+from ..oimComponent import oimComponentFourier
+from ..oimParam import oimParam
 
-##############################################################################
 
 class oimBox(oimComponentFourier):
     name="2D Box"
@@ -23,5 +23,3 @@ class oimBox(oimComponentFourier):
     def _imageFunction(self,xx,yy,wl,t):
         return ((np.abs(xx)<=self.params["dx"](wl,t)/2) &
                 (np.abs(yy)<=self.params["dy"](wl,t)/2)).astype(float)
-
-##############################################################################

--- a/oimodeler/oimCustomComponents/oimBox.py
+++ b/oimodeler/oimCustomComponents/oimBox.py
@@ -1,7 +1,7 @@
+import astropy.units as u
+import numpy as np
 
 from oimodeler import oimComponentFourier,oimParam
-import numpy as np
-import astropy.units as u
 
 ##############################################################################
 

--- a/oimodeler/oimCustomComponents/oimFastRotator.py
+++ b/oimodeler/oimCustomComponents/oimFastRotator.py
@@ -7,7 +7,8 @@ Created on Wed Oct 19 12:30:21 2022
 import numpy as np
 from astropy import units as units
 
-from oimodeler import oimParam, oimComponentImage
+from ..oimComponent import oimComponentImage
+from ..oimParam import oimParam
 
 
 def fastRotator(dim0, size, incl, rot, Tpole, lam, beta=0.25):

--- a/oimodeler/oimCustomComponents/oimFastRotator.py
+++ b/oimodeler/oimCustomComponents/oimFastRotator.py
@@ -6,6 +6,7 @@ Created on Wed Oct 19 12:30:21 2022
 """
 import numpy as np
 from astropy import units as units
+
 from oimodeler import oimParam, oimComponentImage
 
 

--- a/oimodeler/oimCustomComponents/oimSpiral.py
+++ b/oimodeler/oimCustomComponents/oimSpiral.py
@@ -7,7 +7,9 @@ Created on Fri Oct 21 12:27:15 2022
 import numpy as np
 from astropy import units as units
 
-from oimodeler import oimParam, oimComponentImage,_standardParameters
+from ..oimComponent import oimComponentImage
+from ..oimParam import oimParam, _standardParameters
+
 
 class oimSpiral(oimComponentImage):
     

--- a/oimodeler/oimCustomComponents/oimSpiral.py
+++ b/oimodeler/oimCustomComponents/oimSpiral.py
@@ -4,10 +4,10 @@ Created on Fri Oct 21 12:27:15 2022
 
 @author: Ame
 """
-
 import numpy as np
-from oimodeler import oimParam, oimComponentImage,_standardParameters
 from astropy import units as units
+
+from oimodeler import oimParam, oimComponentImage,_standardParameters
 
 class oimSpiral(oimComponentImage):
     

--- a/oimodeler/oimData.py
+++ b/oimodeler/oimData.py
@@ -8,7 +8,8 @@ from enum import IntFlag
 import numpy as np
 from astropy.io import fits
 
-import oimodeler as oim
+from .oimUtils import hdulistDeepCopy
+
 
 _oimDataType=["VIS2DATA","VISAMP","VISPHI","T3AMP","T3PHI","FLUXDATA"]
 _oimDataTypeErr=["VIS2ERR","VISAMPERR","VISPHIERR","T3AMPERR","T3PHIERR","FLUXERR"]
@@ -286,7 +287,7 @@ class oimData(object):
         
         self._filteredData=[]
         for data in self._data:
-            self._filteredData.append(oim.hdulistDeepCopy(data))
+            self._filteredData.append(hdulistDeepCopy(data))
             
         if self._filter!=None:
             self._filter.applyFilter(self._filteredData)

--- a/oimodeler/oimData.py
+++ b/oimodeler/oimData.py
@@ -2,11 +2,12 @@
 """
 data for optical interferometry 
 """
+import os
+from enum import IntFlag
 
 import numpy as np
 from astropy.io import fits
-import os
-from enum import IntFlag
+
 import oimodeler as oim
 
 _oimDataType=["VIS2DATA","VISAMP","VISPHI","T3AMP","T3PHI","FLUXDATA"]

--- a/oimodeler/oimDataFilter.py
+++ b/oimodeler/oimDataFilter.py
@@ -2,13 +2,13 @@
 """data filtering/modifying
 
 """
+import os
 
 import numpy as np
 from astropy.io import fits
-import os
+
 import oimodeler as oim
 from oimodeler import oimParam,_standardParameters
-#import numbers
 
 
 ###############################################################################

--- a/oimodeler/oimDataFilter.py
+++ b/oimodeler/oimDataFilter.py
@@ -7,8 +7,9 @@ import os
 import numpy as np
 from astropy.io import fits
 
-import oimodeler as oim
-from oimodeler import oimParam,_standardParameters
+from .oimData import _oimDataType, _oimDataTypeArr
+from .oimDataFilter import cutWavelengthRange
+from .oimParam import oimParam, _standardParameters
 
 
 ###############################################################################
@@ -98,8 +99,8 @@ class oimWavelengthRangeFilter(oimDataFilterComponent):
         
     
     def _filteringFunction(self,data):
-        oim.cutWavelengthRange(data,wlRange =  self.params["wlRange"],
-                               addCut=self.params["addCut"])
+        cutWavelengthRange(data,wlRange =  self.params["wlRange"],
+                           addCut=self.params["addCut"])
 
 ###############################################################################
 
@@ -124,9 +125,9 @@ class oimDataTypeFilter(oimDataFilterComponent):
         
         
         for dtype in self.params["dataType"]:
-            idx= np.where(np.array(oim._oimDataType) == dtype)[0]
+            idx= np.where(np.array(_oimDataType) == dtype)[0]
             if idx.size==1:
-                dtypearr=oim._oimDataTypeArr[idx[0]]
+                dtypearr=_oimDataTypeArr[idx[0]]
                 
                 for datai in data:
                     if datai.name==dtypearr:

--- a/oimodeler/oimFTBackends.py
+++ b/oimodeler/oimFTBackends.py
@@ -2,9 +2,9 @@
 """
 Backends for Fourier Transform computation
 """
-
 import numpy as np
 from scipy import interpolate
+
 import oimodeler as oim
 
 class numpyFFTBackend():

--- a/oimodeler/oimFTBackends.py
+++ b/oimodeler/oimFTBackends.py
@@ -5,7 +5,8 @@ Backends for Fourier Transform computation
 import numpy as np
 from scipy import interpolate
 
-import oimodeler as oim
+from .oimOptions import oimOptions
+
 
 class numpyFFTBackend():
     
@@ -30,8 +31,8 @@ class numpyFFTBackend():
         
         return vc
     
-oim.oimOptions["FTBackend"]=numpyFFTBackend
-oim.oimOptions["AvailableFTBackends"]=[numpyFFTBackend]
+oimOptions["FTBackend"]=numpyFFTBackend
+oimOptions["AvailableFTBackends"]=[numpyFFTBackend]
 
 try:
     import pyfftw
@@ -85,7 +86,7 @@ try:
             
             return vc
         
-    oim.oimOptions["AvailableFTBackends"].append(FFTWBackend)
+    oimOptions["AvailableFTBackends"].append(FFTWBackend)
     
 except:
     pass

--- a/oimodeler/oimFitter.py
+++ b/oimodeler/oimFitter.py
@@ -3,13 +3,13 @@
 model fitting
 
 """
-
-import numpy as np
-from oimodeler import oimParam
-import oimodeler as oim
+import corner
 import emcee
 import matplotlib.pyplot as plt
-import corner
+import numpy as np
+
+import oimodeler as oim
+from oimodeler import oimParam
 
 class oimFitter(object):
     params={}

--- a/oimodeler/oimFitter.py
+++ b/oimodeler/oimFitter.py
@@ -8,15 +8,16 @@ import emcee
 import matplotlib.pyplot as plt
 import numpy as np
 
-import oimodeler as oim
-from oimodeler import oimParam
+from .oimParam import oimParam
+from .oimSimulator import oimSimulator
+
 
 class oimFitter(object):
     params={}
     def __init__(self,*args,**kwargs):
         nargs=len(args)
         if nargs==2:
-            self.simulator=oim.oimSimulator(args[0],args[1])
+            self.simulator=oimSimulator(args[0],args[1])
         elif nargs==1:
             self.simulator=args[0]
         else:

--- a/oimodeler/oimModel.py
+++ b/oimodeler/oimModel.py
@@ -9,7 +9,8 @@ import numpy as np
 from astropy.io import fits
 from astropy import units as units
 
-from oimodeler import oimParamLinker,oimParamInterpolator
+from .oimParam import oimParamLinker, oimParamInterpolator
+
 
 ###############################################################################    
 class oimModel(object):

--- a/oimodeler/oimModel.py
+++ b/oimodeler/oimModel.py
@@ -3,12 +3,12 @@
 creation of models
 
 """
-
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
 import numpy as np
 from astropy.io import fits
 from astropy import units as units
-import matplotlib.pyplot as plt
-import matplotlib.colors as colors
+
 from oimodeler import oimParamLinker,oimParamInterpolator
 
 ###############################################################################    

--- a/oimodeler/oimParam.py
+++ b/oimodeler/oimParam.py
@@ -2,7 +2,6 @@
 """
 model parameter and parameter interpolators
 """
-
 import numpy as np
 from astropy import units as units
 from scipy.interpolate import interp1d

--- a/oimodeler/oimPlots.py
+++ b/oimodeler/oimPlots.py
@@ -2,12 +2,14 @@
 """
 various plotting function and classes
 """
+import os
+
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.collections import LineCollection
 from matplotlib.legend_handler import HandlerLineCollection
-import numpy as np
-import os
 from astropy.io import fits
+
 import oimodeler as oim
 
 ###############################################################################

--- a/oimodeler/oimPlots.py
+++ b/oimodeler/oimPlots.py
@@ -10,7 +10,9 @@ from matplotlib.collections import LineCollection
 from matplotlib.legend_handler import HandlerLineCollection
 from astropy.io import fits
 
-import oimodeler as oim
+from .oimData import oimData
+from .oimUtils import getBaselineName, getBaselineLengthAndPA, getConfigName, getSpaFreq
+
 
 ###############################################################################
 def _errorplot(axe,X,Y,dY,smooth=1, **kwargs ):
@@ -90,7 +92,7 @@ def uvPlot(oifits,extension="OI_VIS2",marker="o", facecolors='red',
            title=None,gridcolor="k",grid=True,fontsize=None,**kwargs):
 
     
-    if isinstance(oifits,oim.oimData):
+    if isinstance(oifits,oimData):
         oifits=oifits.data
     
     kwargs2={}
@@ -205,7 +207,7 @@ def getColorIndices(oifitsList,color,yarr,yname):
                 
                 
             elif color=="byBaseline":
-                    bnames=oim.getBaselineName(datai,yarr,squeeze=False)[j]
+                    bnames=getBaselineName(datai,yarr,squeeze=False)[j]
                     idxj=[]
                     for bname in bnames:
                         if bname in names:
@@ -218,7 +220,7 @@ def getColorIndices(oifitsList,color,yarr,yname):
                     
        
             elif color=="byConfiguration":
-                    conf=oim.getConfigName(datai,yarr,squeeze=False)[j]
+                    conf=getConfigName(datai,yarr,squeeze=False)[j]
                     if conf in names:
                         iconf = names.index(conf)
                     else:
@@ -298,7 +300,7 @@ def oimPlot(oifitsList,xname,yname,axe=None,xunit=None,xunitmultiplier=1,
     res= None
 
     
-    if isinstance(oifitsList,oim.oimData):
+    if isinstance(oifitsList,oimData):
         oifitsList=oifitsList.data
     
     if type(oifitsList)!=type([]):
@@ -392,17 +394,17 @@ def oimPlot(oifitsList,xname,yname,axe=None,xunit=None,xunitmultiplier=1,
                 xdata.append(np.tile(wl[None,:], (nB,1)))
                 
         elif xname=="SPAFREQ":
-            xdata=oim.getSpaFreq(data,arr=yarr,unit=xunit,squeeze=False) 
+            xdata=getSpaFreq(data,arr=yarr,unit=xunit,squeeze=False) 
             
         elif xname=="LENGTH":
-            B=oim.getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[0]
+            B=getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[0]
             xdata=[]
             for idata in range(len(idx_yext)):
                 xdata.append(np.transpose(
                     np.tile(B[idata],(np.shape(data[idata].data[yname])[1],1))))
 
         elif xname=="PA":
-            PA=oim.getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[1]
+            PA=getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[1]
             xdata=[]
             for idata in range(len(idx_yext)):
                 xdata.append(np.transpose(
@@ -445,17 +447,17 @@ def oimPlot(oifitsList,xname,yname,axe=None,xunit=None,xunitmultiplier=1,
                     cdata=[data[i].data[cname] for i in idx_yext]   
                 
             elif cname=="SPAFREQ":
-                cdata=oim.getSpaFreq(data,arr=yarr,unit=cunit,squeez=False) 
+                cdata=getSpaFreq(data,arr=yarr,unit=cunit,squeez=False) 
                 
             elif cname=="LENGTH":
-                B=oim.getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[0]
+                B=getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[0]
                 cdata=[]
                 for idata in range(len(idx_yext)):
                     cdata.append(np.transpose(
                         np.tile(B[idata],(np.shape(data[idata].data[yname])[1],1))))
     
             elif cname=="PA":
-                PA=oim.getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[1]
+                PA=getBaselineLengthAndPA(data,arr=yarr,squeeze=False)[1]
                 cdata=[]
                 for idata in range(len(idx_yext)):
                     cdata.append(np.transpose(

--- a/oimodeler/oimSimulator.py
+++ b/oimodeler/oimSimulator.py
@@ -5,7 +5,8 @@ data/model simulation
 import matplotlib.pyplot as plt
 import numpy as np
 
-import oimodeler as oim
+from .oimData import oimData, oimDataType
+from .oimUtils import hdulistDeepCopy
 
 
 def corrFlux2Vis2(vcompl):
@@ -62,13 +63,13 @@ class oimSimulator(object):
     contains 
     """
     def __init__(self,data=None,model=None,fitter=None,**kwargs):
-        self.data=oim.oimData()
+        self.data=oimData()
         self.simulatedData=None
         self.model=None
     
     
         if data!=None:
-            if isinstance(data,oim.oimData):
+            if isinstance(data,oimData):
                 self.data=data
             else:
                 self.addData(data)
@@ -90,9 +91,9 @@ class oimSimulator(object):
             
     def prepareData(self):
         self.data.prepareData()
-        self.simulatedData=oim.oimData()
+        self.simulatedData=oimData()
         for datai in self.data.data:
-            self.simulatedData.addData(oim.hdulistDeepCopy(datai))
+            self.simulatedData.addData(hdulistDeepCopy(datai))
 
     def compute(self,computeChi2=False,computeSimulatedData=False,checkSimulatedData=True):
         self.vcompl=self.model.getComplexCoherentFlux(self.data.vect_u,
@@ -104,9 +105,9 @@ class oimSimulator(object):
        
         
         if computeSimulatedData==True and (checkSimulatedData==True or self.simulatedData==None):
-            self.simulatedData=oim.oimData()
+            self.simulatedData=oimData()
             for datai in self.data.data:
-                self.simulatedData.addData(oim.hdulistDeepCopy(datai))
+                self.simulatedData.addData(hdulistDeepCopy(datai))
            
         
         
@@ -145,28 +146,28 @@ class oimSimulator(object):
                           
                     
                     elif arrType=="OI_VIS":
-                        if dataType&oim.oimDataType.VISAMP_ABS:
+                        if dataType&oimDataType.VISAMP_ABS:
                             val.append(corrFlux2VisAmpAbs(vcompli))
                             quantities.append("VISAMP")
-                        elif dataType&oim.oimDataType.VISAMP_DIF:
+                        elif dataType&oimDataType.VISAMP_DIF:
                             val.append(corrFlux2VisAmpDif(vcompli))
                             quantities.append("VISAMP")
-                        elif dataType&oim.oimDataType.VISAMP_COR:
+                        elif dataType&oimDataType.VISAMP_COR:
                             val.append(corrFlux2VisAmpCor(vcompli))
                             quantities.append("VISAMP")       
                             
-                        if dataType&oim.oimDataType.VISPHI_ABS:
+                        if dataType&oimDataType.VISPHI_ABS:
                             val.append(corrFlux2VisPhiAbs(vcompli))
                             quantities.append("VISPHI")                        
-                        elif dataType&oim.oimDataType.VISPHI_DIF:
+                        elif dataType&oimDataType.VISPHI_DIF:
                             val.append(corrFlux2VisPhiDif(vcompli))
                             quantities.append("VISPHI") 
                             
                     elif arrType=="OI_T3":
-                        if dataType&oim.oimDataType.T3AMP:
+                        if dataType&oimDataType.T3AMP:
                             val.append(corrFlux2T3Amp(vcompli))
                             quantities.append("T3AMP") 
-                        if  dataType&oim.oimDataType.T3PHI:
+                        if  dataType&oimDataType.T3PHI:
                             val.append(corrFlux2T3Phi(vcompli))
                             quantities.append("T3PHI")                         
                             

--- a/oimodeler/oimSimulator.py
+++ b/oimodeler/oimSimulator.py
@@ -2,10 +2,10 @@
 """
 data/model simulation 
 """
-
-import numpy as np
-import oimodeler as oim
 import matplotlib.pyplot as plt
+import numpy as np
+
+import oimodeler as oim
 
 
 def corrFlux2Vis2(vcompl):

--- a/oimodeler/oimUtils.py
+++ b/oimodeler/oimUtils.py
@@ -2,11 +2,11 @@
 """
 various utilities for optical interferometry
 """
-import numpy as np
-from astropy.io import fits
 import astropy.units as units
+import numpy as np
+from astropy.coordinates import Angle
+from astropy.io import fits
 from astroquery.simbad import Simbad
-from  astropy.coordinates import Angle
 
 ###############################################################################
 


### PR DESCRIPTION
- Fix the order of imports (First `import ...`then `from ... import ...`)

Sorted the order of imports into the following
1.  Standard libraries
2. User made libraries
3. Local modules or package libraries

- Sorted the imports by alphabet as well
- Change all relative imports and change what is imported in the main `__init__.py`