### PR TITLE
Fix imports of __init__.py and outdated example imports

### DIFF
--- a/examples/ExpandingSoftware/createCustomComponentFourier.py
+++ b/examples/ExpandingSoftware/createCustomComponentFourier.py
@@ -96,7 +96,7 @@ m2.showModel(512,0.2,colorbar=False,figsize=(5,5),
 
 
 #%%
-b4=oimBox(dx=oim.oimInterpWl([2e-6,2.4e-6],[5,10]),dy=2,x=20,y=0,f=0.5)
+b4=oimBox(dx=oim.oimInterp("wl", wl=[2e-6,2.4e-6], values=[5,10]),dy=2,x=20,y=0,f=0.5)
 b4.params['dy']=oim.oimParamLinker(b4.params['dx'],'mult',4)
     
 m3=oim.oimModel([b4])

--- a/examples/ExpandingSoftware/createCustomComponentRadialProfileExpRing.py
+++ b/examples/ExpandingSoftware/createCustomComponentRadialProfileExpRing.py
@@ -27,7 +27,7 @@ class oimExpRing(oim.oimComponentRadialProfile):
          super().__init__(**kwargs)
          self.params["d"]=oim.oimParam(**(oim._standardParameters["d"]))
          self.params["fwhm"]=oim.oimParam(**(oim._standardParameters["fwhm"]))
-         
+
          self._dim=dim
          
          self._t = np.array([0]) # constant value <=> static model

--- a/examples/Other/createModelChromatic.py
+++ b/examples/Other/createModelChromatic.py
@@ -13,13 +13,14 @@ path = os.path.dirname(oim.__file__)
 mas2rad=u.mas.to(u.rad)
 
 #Some components
-gd=oim.oimGauss(fwhm=oim.oimInterpWl(wl=[3e-6,3.5e-6,4e-6],value=[1,3,4]),
-                 f=oim.oimInterpWl([3e-6,4e-6],[1,4]))
+gd=oim.oimGauss(fwhm=oim.oimInterp("wl", wl=[3e-6,3.5e-6,4e-6],values=[1,3,4]),
+                 f=oim.oimInterp("wl", wl=[3e-6,4e-6], values=[1,4]))
 ud=oim.oimUD(d=0.7,f=1)
-ud2=oim.oimUD(x=0,y=5,d=1.5,f=oim.oimInterpWl(wl=[3e-6,4e-6],value=[0,1]))
-ud3=oim.oimUD(x=-5,y=2,d=0.5,f=oim.oimInterpWl(wl=[3e-6,4e-6],value=[0.1,1]))
-eg=oim.oimEGauss(fwhm=1,elong=1.5,pa=oim.oimInterpWl([3e-6,4e-6],[20,60]),f=oim.oimInterpWl([3e-6,4e-6],[1,0.1]))
-er=oim.oimERing(din= 8,dout=oim.oimInterpWl([3e-6,4e-6],[15,20]),elong=2,pa=0)
+ud2=oim.oimUD(x=0,y=5,d=1.5,f=oim.oimInterp("wl", wl=[3e-6,4e-6],values=[0,1]))
+ud3=oim.oimUD(x=-5,y=2,d=0.5,f=oim.oimInterp("wl", wl=[3e-6,4e-6],values=[0.1,1]))
+eg=oim.oimEGauss(fwhm=1,elong=1.5,pa=oim.oimInterp("wl", wl=[3e-6,4e-6],
+                                                   values=[20,60]),f=oim.oimInterp("wl", wl=[3e-6,4e-6], values=[1,0.1]))
+er=oim.oimERing(din= 8,dout=oim.oimInterp("wl", wl=[3e-6,4e-6], values=[15,20]),elong=2,pa=0)
 
 #linking some parameters, actually replacing them
 er.params["elong"]=eg.params["elong"]

--- a/oimodeler/__init__.py
+++ b/oimodeler/__init__.py
@@ -12,11 +12,19 @@ import numpy as np
 
 from .oimBasicFourierComponents import *
 from .oimCustomComponents import *
-from .oimData import oimData
-from .oimFitter import oimFitterEmcee
-from .oimModel import oimModel
-from .oimPlots import oimAxes, oimPlot
-from .oimSimulator import oimSimulator
+from .oimComponent import *
+from .oimData import *
+from .oimData import _oimDataType, _oimDataTypeArr, _oimDataTypeErr
+from .oimDataFilter import *
+from .oimFTBackends import *
+from .oimFitter import *
+from .oimModel import *
+from .oimOptions import oimOptions
+from .oimParam import *
+from .oimParam import _standardParameters
+from .oimPlots import *
+from .oimSimulator import *
+from .oimUtils import *
 
 
 np.seterr(invalid='ignore')

--- a/oimodeler/oimDataFilter.py
+++ b/oimodeler/oimDataFilter.py
@@ -8,8 +8,8 @@ import numpy as np
 from astropy.io import fits
 
 from .oimData import _oimDataType, _oimDataTypeArr
-from .oimDataFilter import cutWavelengthRange
 from .oimParam import oimParam, _standardParameters
+from .oimUtils import cutWavelengthRange
 
 
 ###############################################################################


### PR DESCRIPTION
- Bring back the
```python
from <module> import *
```
imports, to make examples work again (tested all by hand).

- Change (not anymore available)
```python3
oimInterpWl -> oimInterp
```