### PR TITLE
 Implement basic operations for oimParam

### DIFF
--- a/oimodeler/oimParam.py
+++ b/oimodeler/oimParam.py
@@ -46,13 +46,6 @@ class oimParam(object):
         self.description = description
         self.unit = unit
 
-    def set(self, **kwargs):
-        for key, value in kwargs.items():
-            try:
-                self.__dict__[key] = value
-            except NameError:
-                print("Note valid parameter : {}".format(value))
-
     def __add__(self, other):
         if isinstance(other, oimParam):
             return self.value + other.value
@@ -97,6 +90,24 @@ class oimParam(object):
                                                                                      self.value, self.error, self.unit.to_string(), self.min, self.max, self.free)
         except:
             return "oimParam at {} is  {}".format(hex(id(self)), type(self))
+
+    def set(self, **kwargs):
+        for key, value in kwargs.items():
+            try:
+                self.__dict__[key] = value
+            except NameError:
+                print("Note valid parameter : {}".format(value))
+
+    def to(self, unit: units.Quantity):
+        """Converts the parameter to a new unit
+
+        Parameters
+        ----------
+        unit: units.Quantity
+        """
+        self.value = self.value*self.unit.to(unit)
+        self.unit = unit
+
 
 
 

--- a/oimodeler/oimParam.py
+++ b/oimodeler/oimParam.py
@@ -56,32 +56,27 @@ class oimParam(object):
     def __add__(self, other):
         if isinstance(other, oimParam):
             return self.value + other.value
-        else:
-            return self.value + value
+        return self.value + other
 
     def __sub__(self, other):
         if isinstance(other, oimParam):
             return self.value - other.value
-        else:
-            return self.value - value
+        return self.value - other
 
     def __mul__(self, other):
         if isinstance(other, oimParam):
             return self.value * other.value
-        else:
-            return self.value * value
+        return self.value * other
 
     def __div__(self, other):
         if isinstance(other, oimParam):
             return self.value / other.value
-        else:
-            return self.value / value
+        return self.value / value
 
     def __floordiv__(self, other):
         if isinstance(other, oimParam):
             return self.value // other.value
-        else:
-            return self.value // value
+        return self.value // value
 
     def __call__(self, wl=None, t=None):
         """ The call function will be useful for wavelength or time dependent

--- a/oimodeler/oimParam.py
+++ b/oimodeler/oimParam.py
@@ -64,12 +64,12 @@ class oimParam(object):
     def __div__(self, other):
         if isinstance(other, oimParam):
             return self.value / other.value
-        return self.value / value
+        return self.value / other
 
     def __floordiv__(self, other):
         if isinstance(other, oimParam):
             return self.value // other.value
-        return self.value // value
+        return self.value // other
 
     def __call__(self, wl=None, t=None):
         """ The call function will be useful for wavelength or time dependent

--- a/oimodeler/oimParam.py
+++ b/oimodeler/oimParam.py
@@ -53,6 +53,36 @@ class oimParam(object):
             except NameError:
                 print("Note valid parameter : {}".format(value))
 
+    def __add__(self, other):
+        if isinstance(other, oimParam):
+            return self.value + other.value
+        else:
+            return self.value + value
+
+    def __sub__(self, other):
+        if isinstance(other, oimParam):
+            return self.value - other.value
+        else:
+            return self.value - value
+
+    def __mul__(self, other):
+        if isinstance(other, oimParam):
+            return self.value * other.value
+        else:
+            return self.value * value
+
+    def __div__(self, other):
+        if isinstance(other, oimParam):
+            return self.value / other.value
+        else:
+            return self.value / value
+
+    def __floordiv__(self, other):
+        if isinstance(other, oimParam):
+            return self.value // other.value
+        else:
+            return self.value // value
+
     def __call__(self, wl=None, t=None):
         """ The call function will be useful for wavelength or time dependent
         parameters. In a simple oimParam it only return the parameter value


### PR DESCRIPTION


This implements some additional features for the oimParam-class which makes it possible to directly use the `+, -, *, /, //` operators with it and other classes such as float, int, etc.

Is this similar to the implementation of the oimParamLinker, and if yes, could this code segment be dropped in the long run?
```python3
class oimParamLinker(object):
    def __init__(self, param, operator="add", fact=0):
        self.param = param
        self.fact = fact

        self.op = None
        self._setOperator(operator)
        self.free = False

    @property
    def unit(self):
        return self.param.unit

    def _setOperator(self, operator):
        if operator == "add":
            self.op = self._add
        elif operator == "mult":
            self.op = self._mult

    def _add(self, val):
        return val + self.fact

    def _mult(self, val):
        return val * self.fact

    def __call__(self, wl=None, t=None):
        return self.op(self.param.__call__(wl, t))
```
If this is maybe the more pythonic implementation of oimParamLinkerthen it could be removed and all other operations like `*=, /=, ..., ==, !=`, etc. could also be implemented.

Here a list of all operations that could be implemented https://docs.python.org/3/library/operator.html