### PR TITLE
Add binning for `oimComponent` and `oimOptions`

### DIFF
--- a/oimodeler/oimBasicFourierComponents.py
+++ b/oimodeler/oimBasicFourierComponents.py
@@ -4,8 +4,7 @@ basic model-components defined in the Fourier plan
 """
 import astropy.units as u
 import numpy as np
-from astropy import units as units
-from scipy.special import j0,j1,jv
+from scipy.special import j0, j1, jv
 from scipy.signal import convolve2d
 from .oimComponent import oimComponentFourier
 from .oimParam import oimParam, _standardParameters

--- a/oimodeler/oimOptions.py
+++ b/oimodeler/oimOptions.py
@@ -5,6 +5,7 @@ from .oimFTBackends import numpyFFTBackend
 # NOTE: The dictionary oimOption contains all the customizable option of oimodeler
 oimOptions = {}
 oimOptions["FTpaddingFactor"] = 8
+oimOptions["FTbinningFactor"] = None
 oimOptions["FTBackend"] = numpyFFTBackend
 
 # TODO: Should this be a dictionary?


### PR DESCRIPTION
- Add binning to `oimOptions` as an entry to the `oimOption["FTbinningFactor"]`, which defaults to None, but if set to an `int`-value, it will up-bin an image before calculation by
```python3
dim = self.params["dim"](wl, t)
if oimOptions["FTbinningFactor"] is not None:
    dim *= 2**oimOptions["FTbinningFactor"]
```
- Add the binning optionality to `oimComponentImage` within the `_getInternalGrid`-method
- Add a new `_binImage`-method to the `oimComponentImage`-class for down-binning an image after calculation before the FourierTransform