### PR TITLE
Remove improper import of oifitsKeepBaselines

### DIFF
--- a/oimodeler/oimDataFilter.py
+++ b/oimodeler/oimDataFilter.py
@@ -4,7 +4,7 @@ import numpy as np
 from .oimUtils import cutWavelengthRange, shiftWavelength, spectralSmoothing, \
     binWavelength, oifitsFlagWithExpression, computeDifferentialError, \
     setMinimumError, getDataArrname, getDataType, _oimDataType, \
-    _oimDataTypeArr, oifitsKeepBaselines\
+    _oimDataTypeArr
 
 
 class oimDataFilterComponent:


### PR DESCRIPTION
oimDataFilter.py tries to import oifitsKeepBaselines from oimUtils (the actual location is oimDataFilter), which breaks the module