### PR TITLE
Fix bug in oimKeepDataType

### DIFF
--- a/oimodeler/oimDataFilter.py
+++ b/oimodeler/oimDataFilter.py
@@ -177,7 +177,7 @@ class oimKeepDataType(oimDataFilterComponent):
         arr2remove = []
         for ihdu, hdunamei in enumerate(hduname):
             if not (hdunamei in arr0 or hdunamei in arr2Keep):
-                extver = data[ihdu].header["EXTVER"]
+                extver = data[ihdu].header.get("EXTVER", 1)
                 arr2remove.append((hdunamei, extver))
             elif hdunamei in arr2Keep:
                 dataTypesi = getDataType(hdunamei)


### PR DESCRIPTION
https://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html

KEYWORD:   EXTVER
REFERENCE: FITS Standard
STATUS:    reserved
HDU:       extension
VALUE:     integer
RANGE:     [1:]
DEFAULT:   1
COMMENT:   version of the extension
DEFINITION: The value field shall contain an integer, to be used to
distinguish among different extensions in a FITS file with the same
type and name, i.e., the same values for XTENSION and EXTNAME. The
values need not start with 1 for the first extension with a particular
value of EXTNAME and need not be in sequence for subsequent values. If
the EXTVER keyword is absent, the file should be treated as if the
value were 1.  This keyword is used to describe an extension and should
not appear in the primary header.
