### PR TITLE
Fix `vis2` by applying complex conjugate

### DIFF
--- a/oimodeler/oimSimulator.py
+++ b/oimodeler/oimSimulator.py
@@ -11,8 +11,8 @@ from .oimPlots import oimWlTemplatePlots, _errorplot, oimPlotParamName,\
 
 def corrFlux2Vis2(vcompl):
     nB = vcompl.shape[0]
-    norm = np.outer(np.ones(nB-1), vcompl[0, :])
-    return np.abs(vcompl[1:, :]/norm)**2
+    norm = np.abs(np.outer(np.ones(nB-1), vcompl[0, :])) ** 2
+    return np.abs(vcompl[1:, :] * vcompl[1:, :].conj()/norm)
 
 
 def corrFlux2VisAmpAbs(vcompl):


### PR DESCRIPTION
I believe the square was taken before the absolute therefore not incorporating the complex conjugate.
This should only cause problems in case there is a non-zero phase in the model that has the vis² calculated.