### PR TITLE
Fix the normalization factor for 2D Gaussian

### DIFF
--- a/oimodeler/oimBasicFourierComponents.py
+++ b/oimodeler/oimBasicFourierComponents.py
@@ -167,7 +167,7 @@ class oimGauss(oimComponentFourier):
 
     def _imageFunction(self, xx, yy, wl, t):
         r2 = (xx**2+yy**2)
-        return np.sqrt(4*np.log(2)*self.params["fwhm"](wl, t)/np.pi) * \
+        return 4*np.log(2)/self.params["fwhm"](wl, t)**2/np.pi * \
             np.exp(-4*np.log(2)*r2/self.params["fwhm"](wl, t)**2)
 
 


### PR DESCRIPTION
The normalization factor from Eq. (15) of Berger and Segransan (2007) is written as sqrt(4ln2/pi)/theta, which is the normalization factor for a 1D Gaussian. In fact, we have a 2D Gaussian, and the correct normalization factor is just the square of that, i.e. 4ln2/pi/theta^2. Currently, in oimodeler we have written sqrt(4ln2*theta/pi), which is wrong in many ways (theta is inside sqrt and in numerator instead of denominator).

This commit at least gets the formula right, which apparently doesn't matter anyway, since the whole thing seems to be normalized somewhere else.