### PR TITLE
Small fixes for FITS tables without EXTVER set.

### DIFF
--- a/oimodeler/oimPlots.py
+++ b/oimodeler/oimPlots.py
@@ -871,7 +871,7 @@ class oimWlTemplatePlots(Figure):
                         arrName = oimPlotParamArr[idx]
                         for hdui in filek:
                             if hdui.name == arrName:
-                                extver = hdui.header["EXTVER"]
+                                extver = hdui.header.get("EXTVER", 1)
                                 if np.any(hdui.data[shapeij]!=0):
                                     s = hdui.data[shapeij].shape[0]
                                     for iB in range(s):

--- a/oimodeler/oimUtils.py
+++ b/oimodeler/oimUtils.py
@@ -1749,10 +1749,10 @@ def oifitsFlagWithExpression(data, arr, extver0, expr, keepOldFlag=False):
             arri = data[iarr].name
             try:
                 if extver0:
-                    if extver0 != data[iarr].header["EXTVER"]:
+                    if extver0 != data[iarr].header.get("EXTVER", 1):
                         ok = False
                 else:
-                    extver = data[iarr].header["EXTVER"]
+                    extver = data[iarr].header.get("EXTVER", 1)
             except:
                 pass
         else:


### PR DESCRIPTION
Note that when popping a hdu without an EXTVER from a hdulist via hdulist.pop(('TABLENAME', 1)) still works even for tables without EXTVER set, so implicitly assuming it to be be 1 will still work.