### PR TITLE
Additions to extinction capabilities

### DIFF
--- a/oimodeler/config/standard_parameters.toml
+++ b/oimodeler/config/standard_parameters.toml
@@ -13,6 +13,14 @@ free = false
 mini = 0
 maxi = 50
 
+[R_V]
+name = 'R_V'
+description = 'Ratio of total to selective extinction'
+free = false
+value = 3.1
+mini = 1
+maxi = 6
+
 [cosi]
 name = "cosi"
 value = 1

--- a/oimodeler/oimComponent.py
+++ b/oimodeler/oimComponent.py
@@ -3,6 +3,7 @@
 
 import copy
 import warnings
+import inspect
 from pathlib import Path
 from typing import Any, Dict, Union
 
@@ -350,10 +351,16 @@ class oimComponentFourier(oimComponent):
 
             self.params["pa"] = oimParam(**_standardParameters["pa"])
 
-        # NOTE: Add extinction if A_V is specified in kwargs
-        if "A_V" in kwargs:
+        # NOTE: Add extinction if extlaw or extincted (use default law) are specified in kwargs
+        if ("extlaw" in kwargs) or (kwargs.get("extincted", False)):
             self.extincted = True
-            self.params["A_V"] = oimParam(**_standardParameters["A_V"])
+            self.extlaw = kwargs.get("extlaw", extlaw) # Take either the supplied extinction law, or the default
+            self.extargs = []
+            for extarg in inspect.getfullargspec(self.extlaw).args[1:]:
+                self.extargs.append(extarg)
+                self.params[extarg] = oimParam(**_standardParameters.get(extarg, {"name":extarg}))
+        if "A_V" in kwargs:
+            raise NotImplementedError("Extinction must now be defined by specifying extlaw or extincted, instead of A_V")
 
         self._eval(**kwargs, checkParam=False)
 
@@ -374,7 +381,7 @@ class oimComponentFourier(oimComponent):
 
         extfactor = 1.0
         if self.extincted:
-            extfactor = 10 ** (-0.4 * extlaw(wl, self.params["A_V"].value))
+            extfactor = 10 ** (-0.4 * self.extlaw(wl, *[self.params[extarg].value for extarg in self.extargs]))
 
         vc = self._visFunction(fxp, fyp, np.hypot(fxp, fyp), wl, t)
         return (
@@ -422,9 +429,9 @@ class oimComponentFourier(oimComponent):
             else:
                 x_arr = xp * self.params["elong"](wl_arr, t_arr)
 
-        extfactor = np.array([1.0])
+        extfactor = 1.0
         if self.extincted:
-            extfactor = 10 ** (-0.4 * extlaw(wl, self.params["A_V"].value))
+            extfactor = 10 ** (-0.4 * self.extlaw(wl, *[self.params[extarg].value for extarg in self.extargs]))
 
         # FIXME: Did I correctly infer the dimensions of the image? (PAB)
         image = (
@@ -466,9 +473,9 @@ class oimComponentFourier(oimComponent):
             else:
                 xx = xp * self.params["elong"](wl, t)
 
-        extfactor = np.array([1.0])
+        extfactor = 1.0
         if self.extincted:
-            extfactor = 10 ** (-0.4 * extlaw(wl, self.params["A_V"].value))
+            extfactor = 10 ** (-0.4 * self.extlaw(wl, *[self.params[extarg].value for extarg in self.extargs]))
 
         # FIXME: Did I correctly infer the dimensions of the image? (PAB)
         return (
@@ -512,10 +519,16 @@ class oimComponentImage(oimComponent):
             else:
                 self.params["elong"] = oimParam(**_standardParameters["elong"])
 
-        # NOTE: Add extinction if A_V is specified in kwargs
-        if "A_V" in kwargs:
+        # NOTE: Add extinction if extlaw or extincted (use default law) are specified in kwargs
+        if ("extlaw" in kwargs) or (kwargs.get("extincted", False)):
             self.extincted = True
-            self.params["A_V"] = oimParam(**_standardParameters["A_V"])
+            self.extlaw = kwargs.get("extlaw", extlaw) # Take either the supplied extinction law, or the default
+            self.extargs = []
+            for extarg in inspect.getfullargspec(self.extlaw).args[1:]:
+                self.extargs.append(extarg)
+                self.params[extarg] = oimParam(**_standardParameters.get(extarg, {"name":extarg}))
+        if "A_V" in kwargs:
+            raise NotImplementedError("Extinction must now be defined by specifying extlaw or extincted, instead of A_V")
 
         if "FTBackend" in kwargs:
             self.FTBackend = kwargs["FTBackend"]()
@@ -572,7 +585,7 @@ class oimComponentImage(oimComponent):
 
         extfactor = 1.0
         if self.extincted:
-            extfactor = 10 ** (-0.4 * extlaw(wl, self.params["A_V"].value))
+            extfactor = 10 ** (-0.4 * self.extlaw(wl, *[self.params[extarg].value for extarg in self.extargs]))
 
         if not (
             self.FTBackend.check(
@@ -631,9 +644,9 @@ class oimComponentImage(oimComponent):
                 else:
                     x_arr *= self.params["elong"](wl_arr, t_arr)
 
-        extfactor = np.array([1.0])
+        extfactor = 1.0
         if self.extincted:
-            extfactor = 10 ** (-0.4 * extlaw(wl, self.params["A_V"].value))
+            extfactor = 10 ** (-0.4 * self.extlaw(wl, *[self.params[extarg].value for extarg in self.extargs]))
 
         im0 = self._internalImage()
         if im0 is None:
@@ -784,10 +797,16 @@ class oimComponentRadialProfile(oimComponent):
                     **_standardParameters["skwPa"]
                 )
 
-        # NOTE: Add extinction if A_V is specified in kwargs
-        if "A_V" in kwargs:
+        # NOTE: Add extinction if extlaw or extincted (use default law) are specified in kwargs
+        if ("extlaw" in kwargs) or (kwargs.get("extincted", False)):
             self.extincted = True
-            self.params["A_V"] = oimParam(**_standardParameters["A_V"])
+            self.extlaw = kwargs.get("extlaw", extlaw) # Take either the supplied extinction law, or the default
+            self.extargs = []
+            for extarg in inspect.getfullargspec(self.extlaw).args[1:]:
+                self.extargs.append(extarg)
+                self.params[extarg] = oimParam(**_standardParameters.get(extarg, {"name":extarg}))
+        if "A_V" in kwargs:
+            raise NotImplementedError("Extinction must now be defined by specifying extlaw or extincted, instead of A_V")
 
         self.params["dim"] = oimParam(**_standardParameters["dim"])
         self._eval(**kwargs, checkParam=False)
@@ -927,9 +946,9 @@ class oimComponentRadialProfile(oimComponent):
             else:
                 x_arr = xp * self.params["elong"](wl_arr, t_arr)
 
-        extfactor = np.array([1.0])
+        extfactor = 1.0
         if self.extincted:
-            extfactor = 10 ** (-0.4 * extlaw(wl, self.params["A_V"].value))
+            extfactor = 10 ** (-0.4 * self.extlaw(wl, *[self.params[extarg].value for extarg in self.extargs]))
 
         r_arr = np.hypot(x_arr, y_arr)
         im = self._radialProfileFunction(r_arr, wl_arr, t_arr)
@@ -977,7 +996,7 @@ class oimComponentRadialProfile(oimComponent):
 
         extfactor = 1.0
         if self.extincted:
-            extfactor = 10 ** (-0.4 * extlaw(wl, self.params["A_V"].value))
+            extfactor = 10 ** (-0.4 * self.extlaw(wl, *[self.params[extarg].value for extarg in self.extargs]))
 
         spf = np.hypot(fxp, fyp)
 

--- a/oimodeler/oimComponent.py
+++ b/oimodeler/oimComponent.py
@@ -185,7 +185,7 @@ class oimComponent:
                         self.params[key].unit = value.unit
 
             elif checkParam:
-                if key not in ["pa", "elong", "cosi", "elliptic", "flat"]:
+                if key not in ["pa", "elong", "cosi", "elliptic", "flat", "extlaw", "extincted"]:
                     warnings.warn(
                         f"{key} not a parameter of {self.name}: ignored"
                     )

--- a/oimodeler/oimExtinction.py
+++ b/oimodeler/oimExtinction.py
@@ -17,3 +17,45 @@ def extlaw_FitzIndeb(
     kappa = interpolate.splev(wavelength, FITZINDEBSPLINE, der=0)
     return A_V * (kappa / 211.4)
 
+def extlaw_Cardelli(wavelength, A_V=10.0, R_V=3.1):
+
+    x = 1e6 / wavelength
+
+    if np.isscalar(x):
+        x = np.array([x])
+
+    a = np.zeros_like(x)
+    b = np.zeros_like(x)
+
+    # Extend the extinction law smoothly to longer wavelengths; assume the
+    # power-law behavior just continues on smoothly
+    idx = (x <= 1.1)
+    if np.any(idx):
+        a[idx] = 0.574 * x[idx]**1.61
+        b[idx] = -0.527 * x[idx]**1.61
+
+    idx = (1.1 <= x) & (x <= 3.3)
+    if np.any(idx):
+        y = x[idx] - 1.82
+        a[idx] = 1.0 + 0.17699 * y - 0.50447 * y**2 - 0.02427 * y**3 + 0.72085 * y**4 + 0.01979 * y**5 - 0.77530 * y**6 + 0.32999 * y**7
+        b[idx] = 1.41338 * y + 2.28305 * y**2 + 1.07233 * y**3 - 5.38434 * y**4 - 0.62251 * y**5 + 5.30260 * y**6 - 2.09002 * y**7
+
+    idx = (3.3 <= x) & (x <= 8.0)
+    if np.any(idx):
+        F_a = np.zeros(idx.sum())
+        F_b = np.zeros(idx.sum())
+        idx2 = (8.0 >= x[idx]) & (x[idx] >= 5.9)
+        if np.any(idx2):
+            z = x[idx][idx2] - 5.9
+            F_a[idx2] = -0.04473 * z**2 - 0.009779 * z**3
+            F_b[idx2] = 0.2130 * z**2 + 0.1207 * z**3
+        a[idx] = 1.752 - 0.316 * x[idx] - 0.104/((x[idx] - 4.67)**2 + 0.341) + F_a
+        b[idx] = -3.090 + 1.825 * x[idx] + 1.206/((x[idx] - 4.62)**2 + 0.263) + F_b
+
+    idx = (8.0 <= x) & (x <= 10.0)
+    if np.any(idx):
+        z = x[idx] - 8.0
+        a[idx] = -1.073 - 0.628 * z + 0.137 * z**2 - 0.070 * z**3
+        b[idx] = 13.670 + 4.257 * z - 0.420 * z**2 + 0.374 * z**3
+
+    return (a + b/R_V) * A_V

--- a/oimodeler/oimExtinction.py
+++ b/oimodeler/oimExtinction.py
@@ -20,7 +20,7 @@ def extlaw_FitzIndeb(
     kappa = interpolate.splev(wavelength, FITZINDEBSPLINE, der=0)
     return A_V * (kappa / 211.4)
 
-def extlaw_Cardelli(wavelength, A_V=10.0, R_V=3.1):
+def extlaw_Cardelli89(wavelength, A_V=10.0, R_V=3.1):
     """Extinction law from Cardelli et al. (1989, ApJ 345, 245).
     Appropriate for 0.125-3.5 µm."""
 

--- a/oimodeler/oimExtinction.py
+++ b/oimodeler/oimExtinction.py
@@ -13,11 +13,16 @@ FITZINDEBSPLINE = interpolate.splrep(FITZINDEB[0] / 1e10, FITZINDEB[1], s=1)
 def extlaw_FitzIndeb(
     wavelength: Union[float, np.ndarray], A_V: float = 10.0
 ) -> Union[float, np.ndarray]:
-    """Extinction law."""
+    """Extinction law of Fitzpatrick (1999, PASP, 111, 63) improved by
+    Indebetouw et al. (2005, ApJ, 619, 931), as obtained from VOSA
+    (https://svo2.cab.inta-csic.es/theory/vosa/).
+    Appropriate for 0.02-1000 µm."""
     kappa = interpolate.splev(wavelength, FITZINDEBSPLINE, der=0)
     return A_V * (kappa / 211.4)
 
 def extlaw_Cardelli(wavelength, A_V=10.0, R_V=3.1):
+    """Extinction law from Cardelli et al. (1989, ApJ 345, 245).
+    Appropriate for 0.125-3.5 µm."""
 
     x = 1e6 / wavelength
 


### PR DESCRIPTION
Extinction can now be specified by more than a single parameter (it was just A_V before). I added an example of the Cardelli 1989 law, which takes A_V and R_V.

This is not backwards compatible (if the user supplies A_V now it will cause an exception). To get the old behavior, when defining a model component, set extinction=True, and then use A_V as a normal parameter (it still defaults to the FitzIndeb extinction law).