### PR TITLE
Feat/temp grad

### DIFF
--- a/examples/ExpandingSoftware/createCustomComponentRadialProfileExpRing.py
+++ b/examples/ExpandingSoftware/createCustomComponentRadialProfileExpRing.py
@@ -6,9 +6,9 @@ Created on Tue Dec 14 14:39:36 2021
 """
 
 import astropy.units as u
-import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib import colors
 
 import oimodeler as oim
 
@@ -20,37 +20,22 @@ class oimExpRing(oim.oimComponentRadialProfile):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.params["d"] = oim.oimParam(**(oim._standardParameters["d"]))
-        self.params["dim"] = oim.oimParam(**(oim._standardParameters["dim"]))
-        self.params["fwhm"] = oim.oimParam(**(oim._standardParameters["fwhm"]))
-
-        self._t = np.array([0])  # constant value <=> static model
-        self._wl = None  # np.array([0.5,1])*1e-6
-        # self._r = np.arange(0, self._dim)*pixSize
+        self.params["d"] = oim.oimParam(base="d")
+        self.params["dim"] = oim.oimParam(base="dim")
+        self.params["fwhm"] = oim.oimParam(base="fwhm")
 
         # NOTE: Finally, call the _eval function that allow the parameters to be processed
         self._eval(**kwargs)
 
     def _radialProfileFunction(self, r, wl, t):
-
-        r0 = self.params["d"](wl, t) / 2
-        fwhm = self.params["fwhm"](wl, t)
-        I = np.nan_to_num(
-            (r > r0).astype(float) * np.exp(-0.692 * np.divide(r - r0, fwhm)),
-            nan=0,
-        )
-        return I
+        r0, fwhm = self.d(wl, t) / 2, self.fwhm(wl, t)
+        return (r > r0) * np.exp(-0.692 * np.divide(r - r0, fwhm))
 
     @property
-    def _r(self):
-        fwhm_max = self.params["fwhm"](1e99)
-        r0_max = self.params["d"](1e99)
+    def r(self):
+        fwhm_max, r0_max = self.fwhm(1e99), self.d(1e99)
         rmax = r0_max + 8 * fwhm_max
-        return np.linspace(0, 1, self.params["dim"].value) * rmax
-
-    @_r.setter
-    def _r(self, r):
-        pass
+        return np.linspace(0, 1, self.dim.value) * rmax
 
 
 # NOTE: Create UD model for radial profile

--- a/oimodeler/oimComponent.py
+++ b/oimodeler/oimComponent.py
@@ -872,8 +872,8 @@ class oimComponentRadialProfile(oimComponent):
         self._wl = None  # None value <=> All wavelengths (from Data)
         self._t = [0]  # This component is static
         self.normalizeImage = True
-
         self.params["dim"] = oimParam(base="dim")
+        self._r, self._dr = None, None
 
         # NOTE: Add ellipticity if either elong or pa is specified in kwargs
         if any(x in kwargs for x in ["cosi", "elong", "pa"]) or kwargs.pop(
@@ -916,16 +916,24 @@ class oimComponentRadialProfile(oimComponent):
         self._eval(**kwargs, checkParam=False)
 
     @property
-    def _r(self) -> None | NDArray[np.float64]:
+    def r(self) -> None | NDArray[np.float64]:
         """Gets the radial profile (mas)."""
-        return None
+        return self._r
+
+    @property
+    def dr(self) -> None | NDArray[np.float64]:
+        """Gets the integration weights (mas)."""
+        if self._dr is None:
+            self._dr = np.gradient(self.r)
+
+        return self._dr
 
     def _getInternalGrid(self, simple=True, flatten=False, wl=None, t=None):
         wl0 = np.unique(wl) if self._wl is None else self._wl
         t0 = np.unique(t) if self._t is None else self._t
 
-        r = self._r
-        if self._r is None:
+        r = self.r
+        if r is None:
             pix = self._pixSize * units.rad.to(units.mas)
             r = np.linspace(0, self.dim.value - 1, self.dim.value) * pix
 
@@ -1018,78 +1026,7 @@ class oimComponentRadialProfile(oimComponent):
 
         return im
 
-    def hankel(
-        self,
-        r: NDArray[np.float64],
-        wl: NDArray[np.float64],
-        t: NDArray[np.float64],
-        ucoord: NDArray[np.float64],
-        vcoord: NDArray[np.float64],
-    ) -> NDArray[np.complex128]:
-        """Computes the nth-order Hankel transform of the radial intensity.
-
-        Parameters
-        ----------
-        r : NDArray[np.float64]
-            Radius (rad).
-        wl : NDArray[np.float64]
-            Wavelength (m).
-        t : NDArray[np.float64]
-            Time (s).
-        ucoord : NDArray[np.float64]
-            The u coord (Mλ).
-        vcoord : NDArray[np.float64]
-            The v coord (Mλ).
-
-        Returns
-        -------
-        NDArray[np.complex128]
-            The complex coherent flux.
-
-        Notes
-        -----
-        Integration is performed using a manual implementation of
-        the trapezoidal rule to enable matrix multiplication.
-        This improves performance.
-        """
-        # TODO: Performance: Move the `np.unique` lines into ``oimData``
-        wl0, wl_idx = np.unique(wl, return_inverse=True)
-        t0, t_idx = np.unique(t, return_inverse=True)
-        sfreq0, sfreq0_idx, sfreq_idx = np.unique(
-            np.hypot(ucoord, vcoord),
-            return_index=True,
-            return_inverse=True,
-        )
-
-        Ir0 = self.getInternalRadialProfile(wl0, t0)
-        kr = 2.0 * np.pi * r[:, np.newaxis] * sfreq0[np.newaxis, :]
-        kernel = j0(kr)
-
-        # FIXME: Not yet tested for correct output values.
-        if self.asymmetric:
-            psi = np.arctan2(ucoord[sfreq0_idx], vcoord[sfreq0_idx])
-            for i in range(1, self.modulation + 1):
-                skwi = getattr(self, f"skw{i}")(wl, t)
-                skwPai = getattr(self, f"skwPa{i}").qty(wl, t).to(u.rad).value
-                kernel += (
-                    (-1j) ** i * skwi * np.cos(i * (psi - skwPai)) * jv(i, kr)
-                )
-
-        kernel *= 2 * np.pi * (r * np.gradient(r))[:, np.newaxis]
-
-        # TODO: Grid is overcomputed: (nwl * nuv) > (nwl * nsfreq)
-        res0 = Ir0 @ kernel
-        if Ir0.shape[0] == 1:
-            res = res0[0, wl_idx, sfreq_idx]
-        # FIXME: Test if correct for ``(Ir0.shape[0] = nt0) != 1``
-        else:
-            res = res0[t_idx, wl_idx, sfreq_idx]
-
-        return res * 1e23 + 0j
-
-    # TODO: Make this work generally with any radial function and a Hankel transform
     def getComplexCoherentFlux(self, ucoord, vcoord, wl=None, t=None):
-
         wl = ucoord * 0 if wl is None else wl
         t = ucoord * 0 if t is None else t
 
@@ -1099,11 +1036,19 @@ class oimComponentRadialProfile(oimComponent):
             co, si = np.cos(pa_rad), np.sin(pa_rad)
             fxp = ucoord * co - vcoord * si
             fyp = ucoord * si + vcoord * co
+            fxp /= 1 / self.cosi(wl, t) if self.flat else self.elong(wl, t)
 
-            if self.flat:
-                fxp *= self.cosi(wl, t)
-            else:
-                fxp /= self.elong(wl, t)
+        # TODO: Performance: Move the `np.unique` lines into ``oimData``
+        wl0, wl_idx = np.unique(wl, return_inverse=True)
+        t0, t_idx = np.unique(t, return_inverse=True)
+
+        # TODO: Check if these unique ``sfreq`` actually cover
+        # all baseline angles as well.
+        sfreq0, sfreq0_idx, sfreq_idx = np.unique(
+            np.hypot(fxp, fyp),
+            return_index=True,
+            return_inverse=True,
+        )
 
         extfactor = 1.0
         if self.extincted:
@@ -1114,8 +1059,33 @@ class oimComponentRadialProfile(oimComponent):
                 )
             )
 
+        Ir0 = self.getInternalRadialProfile(wl0, t0)
+        r = self.r * units.mas.to(units.rad)
+        kr = 2.0 * np.pi * r[:, np.newaxis] * sfreq0[np.newaxis, :]
+        kernel = j0(kr)
+
+        # FIXME: Not yet tested for correct output values.
+        # TODO: Make wl and t here unique as well.
+        if self.asymmetric:
+            psi = np.arctan2(fxp[sfreq0_idx], fyp[sfreq0_idx])
+            for i in range(1, self.modulation + 1):
+                skwi = getattr(self, f"skw{i}")(wl, t)
+                skwPai = getattr(self, f"skwPa{i}").qty(wl, t).to(u.rad).value
+                kernel += (
+                    (-1j) ** i * skwi * np.cos(i * (psi - skwPai)) * jv(i, kr)
+                )
+
+        dr = self.dr * units.mas.to(units.rad)
+        kernel *= (2 * np.pi * r * dr)[:, np.newaxis]
+
+        # TODO: Grid is overcomputed: (nwl * nuv) < (nwl * nsfreq)
+        vc0 = Ir0 @ kernel * 1e23 + 0j
+
+        # FIXME: Test if correct for ``(Ir0.shape[0] = nt0) != 1``
+        vc = vc0[t_idx if Ir0.shape[0] != 1 else 0, wl_idx, sfreq_idx]
+
         return (
-            self.hankel(self._r * units.mas.to(units.rad), wl, t, fxp, fyp)
+            vc
             * self._ftTranslateFactor(fxp, fyp, wl, t)
             * self.f(wl, t)
             * extfactor

--- a/oimodeler/oimComponent.py
+++ b/oimodeler/oimComponent.py
@@ -1030,44 +1030,44 @@ class oimComponentRadialProfile(oimComponent):
         wl = ucoord * 0 if wl is None else wl
         t = ucoord * 0 if t is None else t
 
-        fxp, fyp = ucoord, vcoord
-        if self.elliptic:
-            pa_rad = self.pa.qty(wl, t).to(units.rad).value
-            co, si = np.cos(pa_rad), np.sin(pa_rad)
-            fxp = ucoord * co - vcoord * si
-            fyp = ucoord * si + vcoord * co
-            fxp /= 1 / self.cosi(wl, t) if self.flat else self.elong(wl, t)
-
         # TODO: Performance: Move the `np.unique` lines into ``oimData``
-        wl0, wl_idx = np.unique(wl, return_inverse=True)
-        t0, t_idx = np.unique(t, return_inverse=True)
-
-        # TODO: Check if these unique ``sfreq`` actually cover
-        # all baseline angles as well.
-        sfreq0, sfreq0_idx, sfreq_idx = np.unique(
-            np.hypot(fxp, fyp),
-            return_index=True,
-            return_inverse=True,
+        wl0, idx_wl = np.unique(wl, return_inverse=True)
+        t0, idx_t = np.unique(t, return_inverse=True)
+        uvcoord0, idx_uvcoord = np.unique(
+            np.vstack((ucoord, vcoord)), return_inverse=True, axis=1
         )
+
+        # TODO: Make this into a matrix multiplication (no need for rearranging)
+        fxp0, fyp0 = uvcoord0
+        if self.elliptic:
+            pa_rad = self.pa.qty(wl0, t0).to(units.rad).value
+            co, si = np.cos(pa_rad), np.sin(pa_rad)
+            fxp0, fyp0 = fxp0 * co - fyp0 * si, fxp0 * si + fyp0 * co
+            fxp0 /= 1 / self.cosi(wl0, t0) if self.flat else self.elong(wl, t0)
 
         extfactor = 1.0
         if self.extincted:
             extfactor = 10 ** (
                 -0.4
                 * self.extlaw(
-                    wl, *[self.params[extarg].value for extarg in self.extargs]
+                    wl0,
+                    *[self.params[extarg].value for extarg in self.extargs],
                 )
             )
 
         Ir0 = self.getInternalRadialProfile(wl0, t0)
         r = self.r * units.mas.to(units.rad)
-        kr = 2.0 * np.pi * r[:, np.newaxis] * sfreq0[np.newaxis, :]
+        kr = (
+            2.0
+            * np.pi
+            * r[:, np.newaxis]
+            * np.hypot(fxp0, fyp0)[np.newaxis, :]
+        )
         kernel = j0(kr)
 
         # FIXME: Not yet tested for correct output values.
-        # TODO: Make wl and t here unique as well.
         if self.asymmetric:
-            psi = np.arctan2(fxp[sfreq0_idx], fyp[sfreq0_idx])
+            psi = np.arctan2(fxp0, fyp0)
             for i in range(1, self.modulation + 1):
                 skwi = getattr(self, f"skw{i}")(wl, t)
                 skwPai = getattr(self, f"skwPa{i}").qty(wl, t).to(u.rad).value
@@ -1078,18 +1078,16 @@ class oimComponentRadialProfile(oimComponent):
         dr = self.dr * units.mas.to(units.rad)
         kernel *= (2 * np.pi * r * dr)[:, np.newaxis]
 
-        # TODO: Grid is overcomputed: (nwl * nuv) < (nwl * nsfreq)
+        # TODO: Grid is overcomputed: (nwl * nuv[m]) < (nwl * nuv[cycle/rad])
         vc0 = Ir0 @ kernel * 1e23 + 0j
-
-        # FIXME: Test if correct for ``(Ir0.shape[0] = nt0) != 1``
-        vc = vc0[t_idx if Ir0.shape[0] != 1 else 0, wl_idx, sfreq_idx]
-
-        return (
-            vc
-            * self._ftTranslateFactor(fxp, fyp, wl, t)
-            * self.f(wl, t)
+        vc0 *= (
+            self._ftTranslateFactor(fxp0, fyp0, wl0, t0)
+            * self.f(wl0, t0)
             * extfactor
         )
+
+        # FIXME: Test if correct for ``(Ir0.shape[0] = nt0) != 1``
+        return vc0[idx_t if Ir0.shape[0] != 1 else 0, idx_wl, idx_uvcoord]
 
 
 class oimComponentFitsImage(oimComponentImage):

--- a/oimodeler/oimCustomComponents/oimExpRing.py
+++ b/oimodeler/oimCustomComponents/oimExpRing.py
@@ -6,10 +6,9 @@ Created on Fri Oct 21 12:27:15 2022
 """
 
 import numpy as np
-from astropy import units
 
 from ..oimComponent import oimComponentRadialProfile
-from ..oimParam import _standardParameters, oimParam
+from ..oimParam import oimParam
 
 
 class oimExpRing(oimComponentRadialProfile):
@@ -20,33 +19,23 @@ class oimExpRing(oimComponentRadialProfile):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.params["d"] = oimParam(**(_standardParameters["d"]))
-        self.params["fwhm"] = oimParam(**(_standardParameters["fwhm"]))
-        self.params["dim"] = oimParam(**(_standardParameters["dim"]))
-
-        self._t = np.array([0])  # constant value <=> static model
-        self._wl = None  # np.array([0.5,1])*1e-6
-
-        # Finally call the _eval function that allow the parameters to be processed
+        self.params["d"] = oimParam(base="d")
+        self.params["fwhm"] = oimParam(base="fwhm")
+        self.params["dim"] = oimParam(base="dim")
         self._eval(**kwargs)
 
-    def _radialProfileFunction(self, r, wl, t):
-
-        r0 = self.params["d"](wl, t) / 2
-        fwhm = self.params["fwhm"](wl, t)
-        I = np.nan_to_num(
-            (r > r0).astype(float) * np.exp(-0.692 * np.divide(r - r0, fwhm)),
-            nan=0,
-        )
-        return I
-
     @property
-    def _r(self):
+    def r(self):
         if False:
-            fwhm_max = np.max(self.params["fwhm"](self._wl, self._t))
-            r0_max = np.max(self.params["d"](self._wl, self._t)) / 2
+            fwhm_max = np.max(self.fwhm(self._wl, self._t))
+            r0_max = np.max(self.d(self._wl, self._t)) / 2
         else:
-            fwhm_max = self.params["fwhm"](1e99)
-            r0_max = self.params["d"](1e99)
+            fwhm_max, r0_max = self.fwhm(1e99), self.d(1e99)
+
         rmax = r0_max + 8 * fwhm_max
-        return np.linspace(0, 1, self.params["dim"].value) * rmax
+        self._r = np.linspace(0, 1, self.dim.value) * rmax
+        return self._r
+
+    def _radialProfileFunction(self, r, wl, t):
+        r0, fwhm = self.d(wl, t) / 2, self.fwhm(wl, t)
+        return (r > r0) * np.exp(-0.692 * np.divide(r - r0, fwhm))

--- a/oimodeler/oimCustomComponents/oimRadialRing.py
+++ b/oimodeler/oimCustomComponents/oimRadialRing.py
@@ -52,10 +52,25 @@ class oimRadialRing(oimComponentRadialProfile):
         self.params["din"] = oimParam(**_standardParameters["din"])
         self.params["dout"] = oimParam(**_standardParameters["dout"])
         self.params["p"] = oimParam(**_standardParameters["p"])
-
-        self._t = np.array([0])  # constant value <=> static model
-        self._wl = None
         self._eval(**kwargs)
+
+    @property
+    def r(self):
+        """Gets the radial profile [mas]."""
+        rin, rout = self.din.value / 2, self.dout.value / 2
+        dim, dist = self.dim.value, self.dist.value
+        grid_type = oimOptions.model.grid.type
+
+        rin, rout = rin / dist * 1e3, rout / dist * 1e3
+        if grid_type == "linear":
+            self._r = np.linspace(rin, rout, dim)
+        else:
+            if rin <= 0:
+                raise ValueError("Logarithmic grid requires rin > 0.")
+
+            self._r = np.logspace(np.log10(rin), np.log10(rout), dim)
+
+        return self._r
 
     def _radialProfileFunction(
         self, r: np.ndarray, wl: np.ndarray, t: np.ndarray
@@ -75,35 +90,6 @@ class oimRadialRing(oimComponentRadialProfile):
         -------
         radial_profile : numpy.ndarray
         """
-        # HACK: Sets the multi wavelength coordinates properly. Does not account for time, improves computation time.
-        wl, p = np.unique(wl), self.params["p"](wl, t)
-        rin, rout = map(lambda x: self.params[x](wl, t) / 2, ("din", "dout"))
-
-        if len(r.shape) == 3:
-            r = r[0, 0][np.newaxis, np.newaxis, :]
-            wl = wl[np.newaxis, :, np.newaxis]
-        else:
-            r, wl = r[np.newaxis, :], wl[np.newaxis, :]
-
-        image = np.nan_to_num(
-            np.logical_and(r > rin, r < rout).astype(int) * (r / rin) ** p,
-            nan=0,
-        )
+        rin, rout = self.din.value / 2, self.dout.value / 2
+        image = ((r >= rin) & (r <= rout)) * (r / rin) ** self.p(wl, t)
         return image * np.ones_like(wl)
-
-    @property
-    def _r(self):
-        """Gets the radial profile [mas]."""
-        rin, rout = map(lambda x: self.params[x].value / 2, ("din", "dout"))
-        if oimOptions.model.grid.type == "linear":
-            return np.linspace(rin, rout, self.params["dim"].value)
-        return np.logspace(
-            0.0 if rin == 0 else np.log10(rin),
-            np.log10(rout),
-            self.params["dim"].value,
-        )
-
-    @_r.setter
-    def _r(self, r: np.ndarray):
-        """Sets the radius."""
-        pass

--- a/oimodeler/oimCustomComponents/oimRadialRing2.py
+++ b/oimodeler/oimCustomComponents/oimRadialRing2.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from ..oimComponent import oimComponentRadialProfile
 from ..oimOptions import oimOptions
-from ..oimParam import _standardParameters, oimParam
+from ..oimParam import oimParam
 
 
 class oimRadialRing2(oimComponentRadialProfile):
@@ -49,13 +49,29 @@ class oimRadialRing2(oimComponentRadialProfile):
     def __init__(self, **kwargs):
         """The class's constructor."""
         super().__init__(**kwargs)
-        self.params["din"] = oimParam(**_standardParameters["din"])
-        self.params["w"] = oimParam(**_standardParameters["w"])
-        self.params["p"] = oimParam(**_standardParameters["p"])
-
-        self._t = np.array([0])  # constant value <=> static model
-        self._wl = None
+        self.params["din"] = oimParam(base="din")
+        self.params["w"] = oimParam(base="w")
+        self.params["p"] = oimParam(base="p")
         self._eval(**kwargs)
+
+    @property
+    def r(self):
+        """Gets the radial profile [mas]."""
+        rin = self.din.value / 2
+        rout = rin + self.w.value
+        dim, dist = self.dim.value, self.dist.value
+        grid_type = oimOptions.model.grid.type
+
+        rin, rout = rin / dist * 1e3, rout / dist * 1e3
+        if grid_type == "linear":
+            self._r = np.linspace(rin, rout, dim)
+        else:
+            if rin <= 0:
+                raise ValueError("Logarithmic grid requires rin > 0.")
+
+            self._r = np.logspace(np.log10(rin), np.log10(rout), dim)
+
+        return self._r
 
     def _radialProfileFunction(
         self, r: np.ndarray, wl: np.ndarray, t: np.ndarray
@@ -75,37 +91,7 @@ class oimRadialRing2(oimComponentRadialProfile):
         -------
         radial_profile : numpy.ndarray
         """
-        # HACK: Sets the multi wavelength coordinates properly. Does not account for time, improves computation time.
-        wl, p = np.unique(wl), self.params["p"](wl, t)
-        rin = self.params["din"](wl, t) / 2
-        rout = rin + self.params["w"](wl, t)
-
-        if len(r.shape) == 3:
-            r = r[0, 0][np.newaxis, np.newaxis, :]
-            wl = wl[np.newaxis, :, np.newaxis]
-        else:
-            r, wl = r[np.newaxis, :], wl[np.newaxis, :]
-
-        image = np.nan_to_num(
-            np.logical_and(r > rin, r < rout).astype(int) * (r / rin) ** p,
-            nan=0,
-        )
+        rin = self.din(wl, t) / 2
+        rout = rin + self.w(wl, t)
+        image = ((r >= rin) & (r <= rout)) * (r / rin) ** self.p(wl, t)
         return image * np.ones_like(wl)
-
-    @property
-    def _r(self):
-        """Gets the radial profile [mas]."""
-        rin = self.params["din"].value / 2
-        rout = rin + self.params["w"].value
-        if oimOptions.model.grid.type == "linear":
-            return np.linspace(rin, rout, self.params["dim"].value)
-        return np.logspace(
-            0.0 if rin == 0 else np.log10(rin),
-            np.log10(rout),
-            self.params["dim"].value,
-        )
-
-    @_r.setter
-    def _r(self, r: np.ndarray):
-        """Sets the radius."""
-        pass

--- a/oimodeler/oimCustomComponents/oimTempGrad.py
+++ b/oimodeler/oimCustomComponents/oimTempGrad.py
@@ -151,33 +151,34 @@ class oimTempGrad(oimComponentRadialProfile):
 
         self.params["dist"] = oimParam(base="dist")
         self.params["f"].free = False
-        self._wl, self._t = None, [0]
-        self._r_cache, self._r_cache_key = None, None
+        self._cache_key = None
         self._eval(**kwargs)
 
     @property
-    def _r(self) -> NDArray[np.float64]:
+    def r(self) -> NDArray[np.float64]:
         """Gets the radial profile (mas)."""
         rin, rout = self.rin.value, self.rout.value
         dim, dist = self.dim.value, self.dist.value
         grid_type = oimOptions.model.grid.type
 
         key = (rin, rout, dim, dist, grid_type)
-        if key == self._r_cache_key:
-            return self._r_cache
+        if key == self._cache_key:
+            return self._r
 
         rin, rout = rin / dist * 1e3, rout / dist * 1e3
         if grid_type == "linear":
-            r = np.linspace(rin, rout, dim)
-        else:
+            self._r = np.linspace(rin, rout, dim)
+        elif grid_type == "logarithmic":
             if rin <= 0:
                 raise ValueError("Logarithmic grid requires rin > 0.")
 
-            r = np.logspace(np.log10(rin), np.log10(rout), dim)
+            self._r = np.logspace(np.log10(rin), np.log10(rout), dim)
+        else:
+            raise ValueError(f"Selected gridtype '{grid_type}' does not exist!")
 
-        self._r_cache_key = key
-        self._r_cache = r
-        return r
+        self._dr = np.gradient(self._r)
+        self._cache_key = key
+        return self._r
 
     @property
     def Tin(self) -> float:

--- a/oimodeler/oimUtils.py
+++ b/oimodeler/oimUtils.py
@@ -419,14 +419,14 @@ def blackbody(
 
     .. math::
 
-        B_ν(λ,T)=2hc²/λ³ 1/(exp(hc/(λk_B T))-1)
+        B_ν(λ,T)=2hc/λ³ 1/(exp(hc/(λk_B T))-1)
 
     This custom variant is implemented for a more efficient computation (i.e. to
     avoid the overhead of similar implementations like the astropy's
     `astropy.modeling.physical_models.BlackBody`).
     """
     x = const.cgs.h * const.cgs.c / (wl * 1e2 * const.cgs.kB * T)
-    return  2 * const.cgs.h * const.cgs.c / (wl * 1e2)**3 / np.expm1(x)
+    return 2 * const.cgs.h * const.cgs.c / (wl * 1e2) ** 3 / np.expm1(x)
 
 
 def spectral_index(


### PR DESCRIPTION
Changes:
* Add `dr` property to `oimComponent.oimComponentRadialProfile` and rename `_r` -> `r` to adhere to Python style (avoid double privates, such as `__r` that cause issues)
* Adapt all components that inherit from `oimComponentRadialProfile` for the new implementation
* Merge `oimComponent.oimComponentRadialProfile.hankel` with `oimComponent.oimComponentRadialProfile.getComplexCoherentFlux`
* Fix getting the unique values for the baselines to account for identical baseline but differing angles